### PR TITLE
Closes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ O fluxo do projeto segue um ciclo repetível e operacional:
 - Runbooks operacionais: `docs/runbook/`
 - Evidências e diagramas de arquitetura (opcional): `docs/architecture/`
 - Checklist de evidências (se existir no repo): `docs/evidence_checklist.md`
+- Board Scrum (GitHub Project): `docs/github_project_scrum_board.md`
 
 ---
 


### PR DESCRIPTION
## Resumo
Documenta o padrão oficial do GitHub Projects usado no projeto (Scrum Board), incluindo:
campos, views (Scrum Board, Sprint Planning, Roadmap e Pull Requests) e automations.

## Por que
A configuração do board é parte do “processo profissional” do projeto e precisa ser
replicável e fácil de apresentar para terceiros (inclusive entrevistadores).

## Evidência
- Documento: `docs/github_project_scrum_board.md`
- README atualizado apontando para a documentação do board
